### PR TITLE
Update trafaret to 1.2.0

### DIFF
--- a/src/airflow_declarative/schema.py
+++ b/src/airflow_declarative/schema.py
@@ -41,6 +41,7 @@ from .trafaret import (
     Key,
     List,
     Mapping,
+    OptionalKey,
     String,
     TimeDelta,
     cast_interval,
@@ -132,52 +133,52 @@ INTERVAL = (TIMEDELTA | STRING | POSITIVE_INT) >> cast_interval
 PARAMS = Mapping(STRING, ANY)
 VERSION = Enum(1)
 
-OPERATOR_ARGS = Dict(
-    adhoc=BOOLEAN,
-    depends_on_past=BOOLEAN,
-    email=EMAIL,
-    email_on_failure=BOOLEAN,
-    email_on_retry=BOOLEAN,
-    end_date=DATE,
-    execution_timeout=INTERVAL,
-    max_retry_delay=POSITIVE_INT,
-    on_failure_callback=CALLBACK,
-    on_retry_callback=CALLBACK,
-    on_success_callback=CALLBACK,
-    owner=STRING,
-    params=PARAMS,
-    pool=STRING,
-    priority_weight=POSITIVE_INT,
-    queue=STRING,
-    resources=Dict(
-        cpu=POSITIVE_INT,
-        disk=POSITIVE_INT,
-        gpus=POSITIVE_INT,
-        ram=POSITIVE_INT,
-    ).make_optional('*'),
-    retries=POSITIVE_INT,
-    retry_delay=INTERVAL,
-    retry_exponential_backoff=BOOLEAN,
-    run_as_user=STRING,
-    sla=INTERVAL,
-    start_date=DATE,
-    trigger_rule=STRING,
-    wait_for_downstream=BOOLEAN,
-).make_optional('*')
+OPERATOR_ARGS = Dict({
+    OptionalKey('adhoc'): BOOLEAN,
+    OptionalKey('depends_on_past'): BOOLEAN,
+    OptionalKey('email'): EMAIL,
+    OptionalKey('email_on_failure'): BOOLEAN,
+    OptionalKey('email_on_retry'): BOOLEAN,
+    OptionalKey('end_date'): DATE,
+    OptionalKey('execution_timeout'): INTERVAL,
+    OptionalKey('max_retry_delay'): POSITIVE_INT,
+    OptionalKey('on_failure_callback'): CALLBACK,
+    OptionalKey('on_retry_callback'): CALLBACK,
+    OptionalKey('on_success_callback'): CALLBACK,
+    OptionalKey('owner'): STRING,
+    OptionalKey('params'): PARAMS,
+    OptionalKey('pool'): STRING,
+    OptionalKey('priority_weight'): POSITIVE_INT,
+    OptionalKey('queue'): STRING,
+    OptionalKey('resources'): Dict({
+        OptionalKey('cpu'): POSITIVE_INT,
+        OptionalKey('disk'): POSITIVE_INT,
+        OptionalKey('gpus'): POSITIVE_INT,
+        OptionalKey('ram'): POSITIVE_INT,
+    }),
+    OptionalKey('retries'): POSITIVE_INT,
+    OptionalKey('retry_delay'): INTERVAL,
+    OptionalKey('retry_exponential_backoff'): BOOLEAN,
+    OptionalKey('run_as_user'): STRING,
+    OptionalKey('sla'): INTERVAL,
+    OptionalKey('start_date'): DATE,
+    OptionalKey('trigger_rule'): STRING,
+    OptionalKey('wait_for_downstream'): BOOLEAN,
+})
 
-SENSOR_ARGS = OPERATOR_ARGS + Dict(
-    poke_interval=INTERVAL,
-    soft_fail=BOOLEAN,
-    timeout=POSITIVE_INT,
-).make_optional('*')
+SENSOR_ARGS = OPERATOR_ARGS + Dict({
+    OptionalKey('poke_interval'): INTERVAL,
+    OptionalKey('soft_fail'): BOOLEAN,
+    OptionalKey('timeout'): POSITIVE_INT,
+})
 
 OPERATOR = (
     Dict({
-        Key('class'): CLASS,
-        Key('callback'): CLASS | CALLBACK,
-        Key('callback_args'): PARAMS,
-        Key('args'): OPERATOR_ARGS.allow_extra('*'),
-    }).make_optional('*') &
+        OptionalKey('class'): CLASS,
+        OptionalKey('callback'): CLASS | CALLBACK,
+        OptionalKey('callback_args'): PARAMS,
+        OptionalKey('args'): OPERATOR_ARGS.allow_extra('*'),
+    }) &
     check_for_class_callback_collisions &
     ensure_callback_args
 )
@@ -186,11 +187,11 @@ OPERATORS = Mapping(STRING, OPERATOR)
 
 SENSOR = (
     Dict({
-        Key('class'): CLASS,
-        Key('callback'): CLASS | CALLBACK,
-        Key('callback_args'): PARAMS,
-        Key('args'): SENSOR_ARGS.allow_extra('*'),
-    }).make_optional('*') &
+        OptionalKey('class'): CLASS,
+        OptionalKey('callback'): CLASS | CALLBACK,
+        OptionalKey('callback_args'): PARAMS,
+        OptionalKey('args'): SENSOR_ARGS.allow_extra('*'),
+    }) &
     check_for_class_callback_collisions &
     ensure_callback_args
 )
@@ -202,26 +203,29 @@ FLOW = Mapping(
     value=List(STRING, min_length=1)
 )
 
-DAG_ARGS = Dict(
-    catchup=BOOLEAN,
-    concurrency=POSITIVE_INT,
-    dagrun_timeout=INTERVAL,
-    default_args=SENSOR_ARGS,  # Sensor args is a superset of all the args.
-    description=STRING,
-    end_date=DATE,
-    max_active_runs=POSITIVE_INT,
-    orientation=STRING,
-    schedule_interval=INTERVAL,
-    sla_miss_callback=CALLBACK,
-    start_date=DATE,
-).make_optional('*')
+DAG_ARGS = Dict({
+    OptionalKey('catchup'): BOOLEAN,
+    OptionalKey('concurrency'): POSITIVE_INT,
+    OptionalKey('dagrun_timeout'): INTERVAL,
+
+    # Sensor args is a superset of all the args.
+    OptionalKey('default_args'): SENSOR_ARGS,
+
+    OptionalKey('description'): STRING,
+    OptionalKey('end_date'): DATE,
+    OptionalKey('max_active_runs'): POSITIVE_INT,
+    OptionalKey('orientation'): STRING,
+    OptionalKey('schedule_interval'): INTERVAL,
+    OptionalKey('sla_miss_callback'): CALLBACK,
+    OptionalKey('start_date'): DATE,
+})
 
 WITH_ITEMS = List(ANY) | Dict(using=CALLBACK)
 
 DO_TEMPLATE = Dict({
-    Key('operators', optional=True): OPERATORS,
-    Key('sensors', optional=True): SENSORS,
-    Key('flow', optional=True): FLOW,
+    OptionalKey('operators'): OPERATORS,
+    OptionalKey('sensors'): SENSORS,
+    OptionalKey('flow'): FLOW,
     Key('with_items'): WITH_ITEMS,
 })
 
@@ -235,19 +239,19 @@ SENSOR_DEFAULTS = Dict(
     args=SENSOR_ARGS
 )
 
-DEFAULTS = Dict(
-    operators=OPERATOR_DEFAULTS,
-    sensors=SENSOR_DEFAULTS,
-).make_optional('*')
+DEFAULTS = Dict({
+    OptionalKey('operators'): OPERATOR_DEFAULTS,
+    OptionalKey('sensors'): SENSOR_DEFAULTS,
+})
 
-DAG = Dict(
-    args=DAG_ARGS,
-    defaults=DEFAULTS,
-    do=DO_TEMPLATES,
-    operators=OPERATORS,
-    sensors=SENSORS,
-    flow=FLOW,
-).make_optional('*')
+DAG = Dict({
+    OptionalKey('args'): DAG_ARGS,
+    OptionalKey('defaults'): DEFAULTS,
+    OptionalKey('do'): DO_TEMPLATES,
+    OptionalKey('operators'): OPERATORS,
+    OptionalKey('sensors'): SENSORS,
+    OptionalKey('flow'): FLOW,
+})
 
 DAGS = Mapping(
     key=STRING,
@@ -256,5 +260,5 @@ DAGS = Mapping(
 
 SCHEMA = Dict({
     Key('dags'): DAGS,
-    Key('version', optional=True): VERSION,
+    OptionalKey('version'): VERSION,
 })

--- a/src/airflow_declarative/schema.py
+++ b/src/airflow_declarative/schema.py
@@ -66,7 +66,7 @@ def ensure_schema(schema):
     :returns: Airflow DAGs schema.
     :rtype: dict
     """
-    return SCHEMA.check_and_return(schema)
+    return SCHEMA.check(schema)
 
 
 def dump(schema, *args, **kwargs):
@@ -123,7 +123,7 @@ BOOLEAN = Bool()
 CALLBACK = Callback()
 CLASS = Class()
 DATE = Date()
-EMAIL = Email()
+EMAIL = Email
 POSITIVE_INT = Int(gte=0)
 STRING = String()
 TIMEDELTA = TimeDelta()
@@ -218,12 +218,12 @@ DAG_ARGS = Dict(
 
 WITH_ITEMS = List(ANY) | Dict(using=CALLBACK)
 
-DO_TEMPLATE = Dict(
-    operators=OPERATORS,
-    sensors=SENSORS,
-    flow=FLOW,
-    with_items=WITH_ITEMS
-).make_optional('operators', 'sensors', 'flow')
+DO_TEMPLATE = Dict({
+    Key('operators', optional=True): OPERATORS,
+    Key('sensors', optional=True): SENSORS,
+    Key('flow', optional=True): FLOW,
+    Key('with_items'): WITH_ITEMS,
+})
 
 DO_TEMPLATES = List(DO_TEMPLATE)
 
@@ -254,7 +254,7 @@ DAGS = Mapping(
     value=DAG,
 )
 
-SCHEMA = Dict(
-    dags=DAGS,
-    version=VERSION,
-).make_optional('version')
+SCHEMA = Dict({
+    Key('dags'): DAGS,
+    Key('version', optional=True): VERSION,
+})

--- a/src/airflow_declarative/trafaret.py
+++ b/src/airflow_declarative/trafaret.py
@@ -61,6 +61,7 @@ __all__ = (
     'Key',
     'List',
     'Mapping',
+    'OptionalKey',
     'String',
     'TimeDelta',
 
@@ -68,6 +69,12 @@ __all__ = (
     'check_for_class_callback_collisions',
     'ensure_callback_args',
 )
+
+
+class OptionalKey(Key):
+    def __init__(self, name, **kwargs):
+        kwargs.setdefault('optional', True)
+        super(OptionalKey, self).__init__(name, **kwargs)
 
 
 class Date(t.Trafaret):

--- a/tests/dags/good/email.yaml
+++ b/tests/dags/good/email.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017, Rambler Digital Solutions
+# Copyright 2018, Rambler Digital Solutions
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/dags/good/email.yaml
+++ b/tests/dags/good/email.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright 2017, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+dags:
+  dag:
+    args:
+      start_date: 2017-07-27
+      schedule_interval: 1d
+    operators:
+      operator:
+        class: airflow.operators.dummy_operator:DummyOperator
+        args:
+          email: mail@example.org

--- a/tests/dags/good/version.yaml
+++ b/tests/dags/good/version.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright 2017, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: 1
+dags:
+  dag:
+    args:
+      start_date: 2017-07-27
+    operators:
+      operator:
+        class: airflow.operators.dummy_operator:DummyOperator

--- a/tests/dags/good/version.yaml
+++ b/tests/dags/good/version.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017, Rambler Digital Solutions
+# Copyright 2018, Rambler Digital Solutions
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/dags/schema-errors/bad-email.yaml
+++ b/tests/dags/schema-errors/bad-email.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017, Rambler Digital Solutions
+# Copyright 2018, Rambler Digital Solutions
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/dags/schema-errors/bad-email.yaml
+++ b/tests/dags/schema-errors/bad-email.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright 2017, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+dags:
+  dag:
+    args:
+      start_date: 2017-07-27
+      schedule_interval: 1d
+    operators:
+      operator:
+        class: airflow.operators.dummy_operator:DummyOperator
+        args:
+          email: not-an-email

--- a/tests/dags/schema-errors/bad-version.yaml
+++ b/tests/dags/schema-errors/bad-version.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2017, Rambler Digital Solutions
+# Copyright 2018, Rambler Digital Solutions
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/dags/schema-errors/bad-version.yaml
+++ b/tests/dags/schema-errors/bad-version.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright 2017, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: 2
+dags:
+  dag:
+    args:
+      start_date: 2017-07-27
+    operators:
+      operator:
+        class: airflow.operators.dummy_operator:DummyOperator


### PR DESCRIPTION
Add support for `trafaret<2,>=1.0`.

The following changes made since trafaret 0.10 have been accounted in this PR:
1. `Dict.check` method must be called for retrieving a value instead of `Dict.check_and_return`, which essentially is just a wrapper for the `check_and_return` \[1\].
2. `Email` trafaret must be created without parenthesis \[2\].
3. `Dict.make_optional` has been deprecated in favor of using explicit `Key(..., optional=True)` instances. It's still supported, but issues a warning. I applied the substitution to all specific optional keys, ~~but I didn't change the `.make_optional('*')` calls, because I don't like the idea of wrapping \~30 keys of the OPERATOR_ARGS schema to explicit `Key(..., optional=True)`. I asked in https://github.com/Deepwalker/trafaret/issues/44 if there's another option, but for now I decided to keep it as-is.~~ upd: I applied the substitution everywhere, including `.make_optional('*')`.

\[1\]: https://github.com/Deepwalker/trafaret/blob/59bb05cf8c846430555690fc0ce408ec0ffb055d/trafaret/base.py#L122-L123
\[2\]: https://github.com/Deepwalker/trafaret/blob/309fbb4510ebf7c6b0a5110ddc8fd9878219a1c8/tests/test_base.py#L251