### PR TITLE
Fix a pytest warning

### DIFF
--- a/tests/test_bad_dags.py
+++ b/tests/test_bad_dags.py
@@ -33,11 +33,16 @@ import trafaret_config
 import airflow_declarative
 
 
+text_type = type(u'')  # six.text_type
+
+
 def param_id(param):
     if inspect.isclass(param):
         return param.__name__
-    else:
+    elif isinstance(param, text_type):
         return os.path.splitext(os.path.basename(param))[0]
+    else:
+        return None  # Let pytest use its default id generator
 
 
 def examples_path():


### PR DESCRIPTION
The warning fixed there is the following one:
```
tests/test_bad_dags.py:70: RemovedInPytest4Warning: While trying to determine id of parameter expected_exception at position 14 the following exception was raised:
  TypeError: expected str, bytes or os.PathLike object, not tuple
This warning will be an error error in pytest-4.0.
```

The issue was that an exception or a tuple of them being passed to the pytest's `param_id` function caused a `TypeError` being raised when calling `os.path.basename`. Apparently this line should be executed for strings only (to strip off the full path to the DAG yamls).