### PR TITLE
Fix invalid `poke_interval` type: it must be int instead of timedelta

### DIFF
--- a/src/airflow_declarative/schema.py
+++ b/src/airflow_declarative/schema.py
@@ -130,6 +130,9 @@ STRING = String()
 TIMEDELTA = TimeDelta()
 
 INTERVAL = (TIMEDELTA | STRING | POSITIVE_INT) >> cast_interval
+INTERVAL_INT_SECONDS = (TIMEDELTA | STRING | POSITIVE_INT) >> (
+    lambda x: cast_interval(x).total_seconds()
+)
 PARAMS = Mapping(STRING, ANY)
 VERSION = Enum(1)
 
@@ -167,7 +170,7 @@ OPERATOR_ARGS = Dict({
 })
 
 SENSOR_ARGS = OPERATOR_ARGS + Dict({
-    OptionalKey('poke_interval'): INTERVAL,
+    OptionalKey('poke_interval'): INTERVAL_INT_SECONDS,
     OptionalKey('soft_fail'): BOOLEAN,
     OptionalKey('timeout'): POSITIVE_INT,
 })

--- a/tests/test_callback_tasks.py
+++ b/tests/test_callback_tasks.py
@@ -22,8 +22,6 @@ from __future__ import (
     unicode_literals,
 )
 
-import datetime
-
 import mock
 import pytest
 
@@ -52,7 +50,7 @@ def test_callbacks(dag):
     sensor_func = dag.task_dict['sensor_func']
     assert isinstance(sensor_func, GenericSensor)
     assert sensor_func.poke({}) is True
-    assert sensor_func.poke_interval == datetime.timedelta(seconds=10)
+    assert sensor_func.poke_interval == 10.0
 
     worker = dag.task_dict['worker']
     assert isinstance(worker, GenericOperator)


### PR DESCRIPTION
According to the docs \[1\] airflow accepts `poke_interval` only as an `int`, but declarative was treating it as a timedelta.

\[1\]: https://airflow.apache.org/code.html#airflow.sensors.base_sensor_operator.BaseSensorOperator