### PR TITLE
Fix dag->args->default_args schema erroneously accepting extra dict keys

### DIFF
--- a/src/airflow_declarative/schema.py
+++ b/src/airflow_declarative/schema.py
@@ -180,7 +180,7 @@ OPERATOR = (
         OptionalKey('class'): CLASS,
         OptionalKey('callback'): CLASS | CALLBACK,
         OptionalKey('callback_args'): PARAMS,
-        OptionalKey('args'): OPERATOR_ARGS.allow_extra('*'),
+        OptionalKey('args'): (OPERATOR_ARGS + Dict()).allow_extra('*'),
     }) &
     check_for_class_callback_collisions &
     ensure_callback_args
@@ -193,7 +193,7 @@ SENSOR = (
         OptionalKey('class'): CLASS,
         OptionalKey('callback'): CLASS | CALLBACK,
         OptionalKey('callback_args'): PARAMS,
-        OptionalKey('args'): SENSOR_ARGS.allow_extra('*'),
+        OptionalKey('args'): (SENSOR_ARGS + Dict()).allow_extra('*'),
     }) &
     check_for_class_callback_collisions &
     ensure_callback_args

--- a/tests/dags/schema-errors/bad-default-args.yaml
+++ b/tests/dags/schema-errors/bad-default-args.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright 2019, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+dags:
+  dag:
+    args:
+      start_date: 2017-07-27
+      schedule_interval: 1d
+      default_args:
+        blahblah: blipblop
+    operators:
+      operator:
+        callback: tests.utils:operator


### PR DESCRIPTION
This PR fixes a bug which causes all non-existing keys of `default_args` to be treated as valid.

`allow_extra` mutates the trafaret `Dict` instance in-place; which definitely wasn't intended here.