### PR TITLE
Add `from_stdout` option to `with_items` which calls an external command

### DIFF
--- a/src/airflow_declarative/schema.py
+++ b/src/airflow_declarative/schema.py
@@ -223,7 +223,7 @@ DAG_ARGS = Dict({
     OptionalKey('start_date'): DATE,
 })
 
-WITH_ITEMS = List(ANY) | Dict(using=CALLBACK)
+WITH_ITEMS = List(ANY) | Dict(using=CALLBACK) | Dict(from_stdout=STRING)
 
 DO_TEMPLATE = Dict({
     OptionalKey('operators'): OPERATORS,

--- a/src/airflow_declarative/transformer.py
+++ b/src/airflow_declarative/transformer.py
@@ -25,6 +25,7 @@ from __future__ import (
 import json
 import shlex
 import subprocess
+import sys
 from collections import Iterable, Mapping
 from itertools import chain
 
@@ -150,7 +151,13 @@ def transform_with_items(schema, template):
 
 
 def from_stdout(cmd):
-    return json.loads(subprocess.check_output(shlex.split(cmd)).decode())
+    PY2 = sys.version_info[0] == 2
+    if PY2:
+        cmd = cmd.encode('utf8')
+    output = subprocess.check_output(shlex.split(cmd))
+    if not PY2:
+        output = output.decode('utf8')
+    return json.loads(output)
 
 
 def transform_schema_with_items(schema, items):

--- a/src/airflow_declarative/transformer.py
+++ b/src/airflow_declarative/transformer.py
@@ -22,6 +22,9 @@ from __future__ import (
     unicode_literals,
 )
 
+import json
+import shlex
+import subprocess
 from collections import Iterable, Mapping
 from itertools import chain
 
@@ -129,6 +132,8 @@ def transform_with_items(schema, template):
     if isinstance(items, dict):
         if set(items) == {'using'}:
             items = items['using']
+        elif set(items) == {'from_stdout'}:
+            items = from_stdout(items['from_stdout'])
     if hasattr(items, '__call__'):
         items = items()
     if not isinstance(items, Iterable):
@@ -142,6 +147,10 @@ def transform_with_items(schema, template):
         schema.setdefault(key, {})
         schema[key] = merge(schema[key], subschema)
     return schema
+
+
+def from_stdout(cmd):
+    return json.loads(subprocess.check_output(shlex.split(cmd)).decode())
 
 
 def transform_schema_with_items(schema, items):

--- a/tests/dags/good/template-with-from-stdout.yaml
+++ b/tests/dags/good/template-with-from-stdout.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright 2019, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+dags:
+  dag:
+    args:
+      start_date: 2017-07-27
+      schedule_interval: 37m
+    do:
+    - operators:
+        operator_{{ item.some_name }}:
+          callback: tests.utils:Operator
+          callback_args:
+            param: '{{ item.value }}'
+      with_items:
+        from_stdout: >
+          echo '[{"some_name": "foo", "value": {"hello": ["привет"]}}]'

--- a/tests/dags/schema-errors/bad-with-items-both-using-and-from-stdout.yaml
+++ b/tests/dags/schema-errors/bad-with-items-both-using-and-from-stdout.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright 2019, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+dags:
+  dag:
+    args:
+      start_date: 2017-07-27
+      schedule_interval: 37m
+    do:
+    - operators:
+        operator_{{ item.some_name }}:
+          callback: tests.utils:Operator
+          callback_args:
+            param: '{{ item.value }}'
+      with_items:
+        from_stdout: >
+          echo '[{"some_name": "foo", "value": {"hello": ["привет"]}}]'
+        using: tests.utils:gen_items

--- a/tests/test_template_with_from_stdout.py
+++ b/tests/test_template_with_from_stdout.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017, Rambler Digital Solutions
+# Copyright 2019, Rambler Digital Solutions
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ from airflow_declarative.operators import GenericOperator
 
 @pytest.fixture()
 def dag(good_dag_path):
-    path = good_dag_path('template-with-dicts')
+    path = good_dag_path('template-with-from-stdout')
     dags = airflow_declarative.from_path(path)
 
     assert len(dags) == 1
@@ -46,16 +46,4 @@ def test_callback_params(dag):
     foo.execute({})
     assert foo._callback_instance.param == {'hello': ['привет']}
 
-    bar = dag.task_dict['operator_bar']
-    assert isinstance(bar, GenericOperator)
-    bar.execute({})
-    assert bar._callback_instance.param == {'world': ['мир']}
-
-    baz = dag.task_dict['operator_baz']
-    assert isinstance(baz, GenericOperator)
-    baz.execute({})
-    assert baz._callback_instance.param == {'qwerty': ['йцукен']}
-
-    assert set(dag.task_dict) == {
-        'operator_foo', 'operator_bar', 'operator_baz', 'sensor'
-    }
+    assert set(dag.task_dict) == {'operator_foo'}


### PR DESCRIPTION
We already have `using` for `with_items` which calls a Python callback for filling the `with_items` list.

This PR adds another option -- `from_stdout` -- which calls an external command for doing the same.

There's a usage example in the tests.