### PR TITLE
Add some missing keys to `OPERATOR_ARGS` like `task_concurrency`

### DIFF
--- a/src/airflow_declarative/schema.py
+++ b/src/airflow_declarative/schema.py
@@ -144,6 +144,7 @@ OPERATOR_ARGS = Dict({
     OptionalKey('email_on_retry'): BOOLEAN,
     OptionalKey('end_date'): DATE,
     OptionalKey('execution_timeout'): INTERVAL,
+    OptionalKey('executor_config'): Dict(allow_extra='*'),
     OptionalKey('max_retry_delay'): POSITIVE_INT,
     OptionalKey('on_failure_callback'): CALLBACK,
     OptionalKey('on_retry_callback'): CALLBACK,
@@ -154,7 +155,7 @@ OPERATOR_ARGS = Dict({
     OptionalKey('priority_weight'): POSITIVE_INT,
     OptionalKey('queue'): STRING,
     OptionalKey('resources'): Dict({
-        OptionalKey('cpu'): POSITIVE_INT,
+        OptionalKey('cpus'): POSITIVE_INT,
         OptionalKey('disk'): POSITIVE_INT,
         OptionalKey('gpus'): POSITIVE_INT,
         OptionalKey('ram'): POSITIVE_INT,
@@ -165,8 +166,10 @@ OPERATOR_ARGS = Dict({
     OptionalKey('run_as_user'): STRING,
     OptionalKey('sla'): INTERVAL,
     OptionalKey('start_date'): DATE,
+    OptionalKey('task_concurrency'): POSITIVE_INT,
     OptionalKey('trigger_rule'): STRING,
     OptionalKey('wait_for_downstream'): BOOLEAN,
+    OptionalKey('weight_rule'): Enum('downstream', 'upstream', 'absolute'),
 })
 
 SENSOR_ARGS = OPERATOR_ARGS + Dict({

--- a/tests/dags/good/executor-config.yaml
+++ b/tests/dags/good/executor-config.yaml
@@ -1,0 +1,28 @@
+#
+# Copyright 2019, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+dags:
+  dag:
+    args:
+      start_date: 2017-07-27
+      schedule_interval: 1d
+    operators:
+      operator:
+        class: airflow.operators.dummy_operator:DummyOperator
+        args:
+          executor_config:
+            KubernetesExecutor:
+              image: myCustomDockerImage


### PR DESCRIPTION
Some Airflow BaseOperator args were missing in the schema. This PR adds them.

The upstream API reference: https://airflow.apache.org/_api/airflow/models/index.html#airflow.models.BaseOperator