### PR TITLE
Update pylint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup(
             'flake8==3.5.0',
             'isort==4.3.4',
             'mock==2.0.0',
-            'pylint==2.1.1; python_version>="3"',
+            'pylint==2.3.1; python_version>="3"',
             'pytest-cov==2.6.0',
             'pytest-sugar==0.9.1',
             'pytest==3.8.2',


### PR DESCRIPTION
The current master fails in CI on the `lint` stage with the following error (https://travis-ci.org/rambler-digital-solutions/airflow-declarative/jobs/548387138):

```
...
  File "/home/travis/build/rambler-digital-solutions/airflow-declarative/.tox/lint/lib/python3.6/site-packages/pylint/checkers/variables.py", line 1360, in visit_import
    module = next(node.infer_name_module(parts[0]))
AttributeError: 'Import' object has no attribute 'infer_name_module'
```

Apparently this is caused by an updated `astroid` version (which pylint depends on) and is fixed in the newer versions of pylint: https://github.com/PyCQA/astroid/issues/649