### PR TITLE
Drop Airflow 1.8 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,9 @@ airflow-declarative
 Airflow declarative DAGs via YAML.
 
 Compatibility:
+
 - Python 2.7 / 3.5+
-- Airflow 1.8+ (should work with older versions as well, at least down to 1.7)
+- Airflow 1.9+
 
 Key Features
 ============

--- a/tox-pip9.sh
+++ b/tox-pip9.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-pip install 'pip>=9,<10'
-pip install "$@"

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,5 @@
 [tox]
 envlist=
-; Airflow 1.8 contains a `pip.get_installed_distributions()` call,
-; which is not supported by pip>=10: https://github.com/pypa/pip/issues/5243
-    py{27,35,36}-airflow18-pip9,
 ; airflow<1.11 contain a variable named `async` in their setup.py,
 ; which makes them incompatible with python>=3.7.
     py{27,35,36}-airflow19,
@@ -21,7 +18,6 @@ setenv =
     SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 deps =
-    airflow18: apache-airflow>=1.8,<1.9
     airflow19: apache-airflow>=1.9,<1.10
     airflow110: apache-airflow>=1.10,<1.11
 extras =
@@ -31,15 +27,6 @@ commands = make check-coverage
 ; Fix pytest-coverage not working because tox doesn't install
 ; sources to the working dir by default.
 usedevelop = True
-
-; A workaround for installing a specific pip version inside a tox's virtualenv:
-; https://stackoverflow.com/a/39660073
-[testenv:py27-airflow18-pip9]
-install_command = {toxinidir}/tox-pip9.sh {opts} {packages}
-[testenv:py35-airflow18-pip9]
-install_command = {toxinidir}/tox-pip9.sh {opts} {packages}
-[testenv:py36-airflow18-pip9]
-install_command = {toxinidir}/tox-pip9.sh {opts} {packages}
 
 [testenv:lint]
 basepython = python3


### PR DESCRIPTION
Airflow 1.8 is quite old now so I think it should be ok to drop its support.

This allows to get rid of a horrible hack with the `tox-pip9.sh` script.