### PR TITLE
Fix `with_items` raising TypeError for jinja like `{{ 1 + item.value }}`

### DIFF
--- a/src/airflow_declarative/transformer.py
+++ b/src/airflow_declarative/transformer.py
@@ -88,10 +88,16 @@ class YamlExtension(Extension):
                     # don't yaml twice
                     continue
 
-                var_expr.append(Token(10, 'pipe', u'|'))
-                var_expr.append(Token(10, 'name', u'yaml'))
+                # Wrap the whole expression between the `variable_begin`
+                # and `variable_end` marks in parens:
+                var_expr.insert(1, Token(var_expr[0].lineno, 'lparen', None))
+                var_expr.append(Token(var_expr[-1].lineno, 'rparen', None))
+
+                var_expr.append(Token(token.lineno, 'pipe', '|'))
+                var_expr.append(Token(token.lineno, 'name', 'yaml'))
 
                 var_expr.append(variable_end)
+
                 for token in var_expr:
                     yield token
             else:

--- a/tests/dags/good/template-with-complex-jinja.yaml
+++ b/tests/dags/good/template-with-complex-jinja.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright 2019, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+dags:
+  mydag:
+    args:
+      start_date: 2017-07-27
+      schedule_interval: 1d
+    do:
+    - operators:
+        operator_{{ item.value }}:
+          callback: tests.utils:MultiParamOperator
+          callback_args:
+            param1: '{{ 3 * item.value + 1 }}'  # == 7
+            param2: '{{ (3 * (item.value + 1)) }}'  # == 9
+            param3:
+              a: '{{ 3 * item.value + 1 }}'  # == 7
+      with_items:
+        - value: 2

--- a/tests/test_template_with_complex_jinja.py
+++ b/tests/test_template_with_complex_jinja.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
+
+import pytest
+
+import airflow_declarative
+
+
+@pytest.fixture()
+def dag(good_dag_path):
+    path = good_dag_path('template-with-complex-jinja')
+    dags = airflow_declarative.from_path(path)
+
+    assert len(dags) == 1
+
+    dag = dags[0]
+
+    return dag
+
+
+def test_callback_params(dag):
+    operator = dag.task_dict['operator_2']
+    operator.execute({})
+    assert operator._callback_instance.param1 == 7
+    assert operator._callback_instance.param2 == 9
+    assert operator._callback_instance.param3 == {'a': 7}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -59,6 +59,18 @@ class Operator(object):
         pass
 
 
+class MultiParamOperator(object):
+
+    def __init__(self, context, param1=None, param2=None, param3=None):
+        self.context = context
+        self.param1 = param1
+        self.param2 = param2
+        self.param3 = param3
+
+    def __call__(self):
+        pass
+
+
 class Sensor(object):
 
     def __init__(self, context, param):


### PR DESCRIPTION
For such templates there was an exception:

    TypeError: unsupported operand type(s) for +: 'int' and 'str'

The reason is that we implicitly append `| yaml` to jinja templates in `with_items`, so the template starts to look like `{{ 1 + item.value | yaml }}`, which is effectively an "int + str" expression.

This commit fixes that by implicitly wrapping all templates in parens, so the aforementioned template would become `{{ (1 + item.value) | yaml }}`.