### PR TITLE
Add `testing` doc page

### DIFF
--- a/src/docs/index.rst
+++ b/src/docs/index.rst
@@ -45,6 +45,7 @@ An example of a simple declarative DAG:
 
    intro
    reference
+   testing
 
 
 Indices and tables

--- a/src/docs/reference.rst
+++ b/src/docs/reference.rst
@@ -114,6 +114,9 @@ DAG_ARGS
 The actual meaning of these args can be found in the :class:`airflow.models.DAG`
 doc page.
 
+
+.. _operator_sensor:
+
 OPERATOR / SENSOR
 -----------------
 
@@ -187,6 +190,8 @@ the args more granularly: only to ``sensors`` or only to ``operators``
 (note that defaults specified in ``operators`` would not be applied
 to sensors).
 
+
+.. _flow:
 
 FLOW
 ----

--- a/src/docs/testing.rst
+++ b/src/docs/testing.rst
@@ -1,0 +1,46 @@
+Testing Declarative DAGs
+========================
+
+Unlike DAGs defined with Python, declarative DAGs forcibly draw a strong line
+between the business logic (the Python callbacks and external commands)
+and the DAG definition. This obligatory separation brings some benefits:
+
+- The business logic doesn't have to know anything about Airflow existence
+  (except the :ref:`task context dict <operator_sensor>`).
+- The declaratively defined DAG doesn't have to be executed by Airflow.
+  A custom implementation could be created which could execute the DAGs
+  described with YAML, which is easy to parse.
+- It is much clearer what has to be tested and what is not.
+
+The business logic is completely under your responsibility so it should
+be covered with tests.
+
+The DAG instantiation, however, is not your responsibility, so it
+doesn't have to be covered with tests. It is just enough to ensure
+that the declarative DAG passes the schema validation and looks sensible
+(i.e. all required operators and sensors are defined, the :ref:`flow <flow>`
+contains all required links).
+
+The schema validation could be automated with the following test:
+
+::
+
+    from pathlib import Path
+
+    import pytest
+    from airflow import DAG, declarative
+
+
+    DAG_DIR = Path("share") / "airflow"
+
+
+    @pytest.mark.parametrize("dag_path", DAG_DIR.glob("*.yaml"))
+    def test_load_airflow_dags(dag_path):
+        dags = declarative.load_dags_from_file(dag_path)
+        assert all(isinstance(dag, DAG) for dag in dags)
+
+This test assumes that all of your declarative DAGs are located in
+the ``share/airflow`` directory. It loads all yamls from that directory,
+validates their schemas and transforms them to :class:`airflow.models.DAG`
+instances. If a declarative DAG passes this test, then it can be loaded
+by the actual Airflow.


### PR DESCRIPTION
This PR adds a new doc page describing our approach for testing declarative DAGs at Usermodel.

This branch is deployed at https://airflow-declarative.readthedocs.io/en/add-testing-doc/testing.html