### PR TITLE
Add return for render function

### DIFF
--- a/src/airflow_declarative/__init__.py
+++ b/src/airflow_declarative/__init__.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from . import builder, schema, transformer
 
 
-__all__ = ("from_path", "from_dict")
+__all__ = ("from_path", "from_dict", "render")
 
 
 def from_path(path):

--- a/src/airflow_declarative/__init__.py
+++ b/src/airflow_declarative/__init__.py
@@ -54,8 +54,9 @@ def transform(schema):
 
 
 def render(path):
-    """Print out the transformed schema. Useful for debugging.
+    """Return the transformed schema in yaml format. Useful for debugging.
 
     :param str path: A path to the declarative YAML file.
+    :rtype: str
     """
-    print(schema.dump(transformer.transform(schema.from_path(path))))
+    return schema.dump(transform(schema.from_path(path)))

--- a/tests/test_good_dags.py
+++ b/tests/test_good_dags.py
@@ -45,6 +45,6 @@ def test_good_dags(path):
 
 def test_serde(path):
     schema0 = airflow_declarative.transform(airflow_declarative.schema.from_path(path))
-    content = airflow_declarative.schema.dump(schema0)
+    content = airflow_declarative.render(path)
     schema1 = airflow_declarative.schema.ensure_schema(yaml.load(content))
     assert schema0 == schema1


### PR DESCRIPTION
Render function transform yaml with dags. It's pretty useful but its usefulness limited only with printing yaml to stdout. If this function have return, this limitation will be removed.

This PR adds return value for render function.