### PR TITLE
Add support for different schedule intervals formats

### DIFF
--- a/src/airflow_declarative/schema.py
+++ b/src/airflow_declarative/schema.py
@@ -36,6 +36,7 @@ from .trafaret import (
     Key,
     List,
     Mapping,
+    Null,
     OptionalKey,
     String,
     TimeDelta,
@@ -120,10 +121,12 @@ CALLBACK = Callback()
 CLASS = Class()
 DATE = Date()
 EMAIL = Email
+NULL = Null()
 POSITIVE_INT = Int(gte=0)
 STRING = String()
 TIMEDELTA = TimeDelta()
 
+CRON_PRESETS = Enum("@once", "@hourly", "@daily", "@weekly", "@monthly", "@yearly")
 CRONTAB_OR_INTERVAL = (TIMEDELTA | STRING | POSITIVE_INT) >> cast_crontab_or_interval
 INTERVAL = (TIMEDELTA | STRING | POSITIVE_INT) >> cast_interval
 INTERVAL_INT_SECONDS = (TIMEDELTA | STRING | POSITIVE_INT) >> (
@@ -223,7 +226,7 @@ DAG_ARGS = Dict(
         OptionalKey("end_date"): DATE,
         OptionalKey("max_active_runs"): POSITIVE_INT,
         OptionalKey("orientation"): STRING,
-        OptionalKey("schedule_interval"): CRONTAB_OR_INTERVAL,
+        OptionalKey("schedule_interval"): NULL | CRON_PRESETS | CRONTAB_OR_INTERVAL,
         OptionalKey("sla_miss_callback"): CALLBACK,
         OptionalKey("start_date"): DATE,
     }

--- a/src/airflow_declarative/trafaret.py
+++ b/src/airflow_declarative/trafaret.py
@@ -24,7 +24,7 @@ import re
 
 import trafaret as t
 from croniter import croniter
-from trafaret import Any, Bool, Dict, Email, Enum, Int, Key, List, Mapping, String
+from trafaret import Any, Bool, Dict, Email, Enum, Int, Key, List, Mapping, Null, String
 
 
 try:
@@ -46,6 +46,7 @@ __all__ = (
     "Key",
     "List",
     "Mapping",
+    "Null",
     "OptionalKey",
     "String",
     "TimeDelta",

--- a/tests/dags/good/schedule-interval-cron-preset.yaml
+++ b/tests/dags/good/schedule-interval-cron-preset.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright 2019, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+dags:
+  dag:
+    args:
+      start_date: 2017-07-27
+      schedule_interval: '@daily'
+    operators:
+      operator:
+        class: airflow.operators.dummy_operator:DummyOperator

--- a/tests/dags/good/schedule-interval-none.yaml
+++ b/tests/dags/good/schedule-interval-none.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright 2019, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+dags:
+  dag:
+    args:
+      start_date: 2017-07-27
+      schedule_interval: null
+    operators:
+      operator:
+        class: airflow.operators.dummy_operator:DummyOperator


### PR DESCRIPTION
Dag schedule_interval in airflow except cron expression and timedelta may be None or cron preset. 

This PR adds this two schedule_interval formats.