### PR TITLE
Fix yaml dump in string templates

### DIFF
--- a/src/airflow_declarative/schema.py
+++ b/src/airflow_declarative/schema.py
@@ -77,7 +77,10 @@ def dump(schema, *args, **kwargs):
     """
     kwargs.setdefault("default_flow_style", False)
     kwargs.setdefault("default_style", "")
-    return yaml.dump(schema, Dumper=Dumper, *args, **kwargs)
+
+    # yaml.dump always end the string with '\n...\n' even if explicit_end is False
+    # so just replace it
+    return yaml.dump(schema, Dumper=Dumper, *args, **kwargs).replace("\n...\n", "")
 
 
 class Dumper(yaml.SafeDumper):

--- a/tests/dags/good/template_string_param.yaml
+++ b/tests/dags/good/template_string_param.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright 2017, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+dags:
+  dag:
+    args:
+      start_date: 2017-07-27
+      schedule_interval: 1d
+    do:
+    - operators:
+        some_{{ item.name }}_operator:
+          callback: tests.utils:Operator
+          callback_args:
+            param: 'some_name_for_operator{{ item.id }}.xml'
+      with_items:
+        - id: 1
+          name: first
+        - id: 2
+          name: second


### PR DESCRIPTION
yaml.dump at the end of stream always add '\n...\n' it can't be disabled and it cause errors when templating something in strings.

This PR fixes this behavior.