### PR TITLE
Reference doc: fix incorrect `defaults` schema

### DIFF
--- a/src/airflow_declarative/schema.py
+++ b/src/airflow_declarative/schema.py
@@ -245,16 +245,7 @@ DO_TEMPLATE = Dict(
 
 DO_TEMPLATES = List(DO_TEMPLATE)
 
-OPERATOR_DEFAULTS = OPERATOR
-
-SENSOR_DEFAULTS = SENSOR
-
-DEFAULTS = Dict(
-    {
-        OptionalKey("operators"): OPERATOR_DEFAULTS,
-        OptionalKey("sensors"): SENSOR_DEFAULTS,
-    }
-)
+DEFAULTS = Dict({OptionalKey("operators"): OPERATOR, OptionalKey("sensors"): SENSOR})
 
 DAG = Dict(
     {

--- a/src/docs/reference.rst
+++ b/src/docs/reference.rst
@@ -41,11 +41,15 @@ The anatomy of a declarative DAG:
 
         defaults:
           sensors:
-            # `SENSOR_ARGS`
-            queue: my_sensors_queue
+            # `SENSOR`
+            args:
+              # `SENSOR_ARGS`
+              queue: my_sensors_queue
           operators:
-            # `OPERATOR_ARGS`
-            queue: my_operators_queue
+            # `OPERATOR`
+            args:
+              # `OPERATOR_ARGS`
+              queue: my_operators_queue
 
         args:
           # `DAG_ARGS`


### PR DESCRIPTION
There was an error in schema at the reference page, this PR would fix it.