### PR TITLE
Convert to setup.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,95 +1,73 @@
-# Created by .ignore support plugin (hsz.mobi)
-### Python template
-# Byte-compiled / optimized / DLL files
-__pycache__/
-*.py[cod]
 *$py.class
-
-# C extensions
-*.so
-
-# Distribution / packaging
-.Python
-env/
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-*.egg-info/
-.installed.cfg
-*.egg
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
 *,cover
-.hypothesis/
-
-# Translations
+*.cover
+*.egg
+*.egg-info/
+*.log
+*.manifest
 *.mo
 *.pot
-
-# Django stuff:
-*.log
-local_settings.py
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# pyenv
-.python-version
-
-# celery beat schedule file
-celerybeat-schedule
-
-# dotenv
+*.py[cod]
+*.sage.py
+*.so
+*.spec
+.cache
+.coverage
+.coverage.*
+.dmypy.json
+.eggs/
 .env
-
-# virtualenv
-.venv/
-venv/
-ENV/
-
-# Spyder project settings
-.spyderproject
-
-# Rope project settings
+.hypothesis/
+.idea
+.installed.cfg
+.ipynb_checkpoints
+.mypy_cache/
+.nox/
+.pyre/
+.pytest_cache/
+.Python
+.python-version
 .ropeproject
-
-# Project specifics
+.scrapy
+.spyderproject
+.spyproject
+.tox/
+.venv
+.webassets-cache
+/site
+__pycache__/
+_build/
+build/
+celerybeat-schedule
+coverage.xml
+db.sqlite3
+develop-eggs/
+dist/
+dmypy.json
+docs/_build/
+downloads/
+eggs/
+env.bak/
+ENV/
+env/
+htmlcov/
+instance/
+ipython_config.py
+junit.xml
+lib/
+lib64/
+local_settings.py
+MANIFEST
+nosetests.xml
+parts/
+pip-delete-this-directory.txt
+pip-log.txt
+profile_default/
+sdist/
+share/python-wheels/
+target/
+var/
+venv.bak/
+venv/
 VERSION
+wheels/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+global-exclude *.py[co]
+global-exclude __pycache__
 graft patches
 graft tests
 include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,5 @@
-[coverage:run]
-branch = True
-source =
-    src
-    tests
+[aliases]
+test = pytest
 
 [coverage:report]
 exclude_lines =
@@ -16,6 +13,12 @@ exclude_lines =
 fail_under = 95
 precision = 2
 show_missing = True
+
+[coverage:run]
+branch = True
+source =
+    src
+    tests
 
 [flake8]
 ignore = E203,W503

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,84 @@ order_by_type = true
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 use_parentheses = True
 
+[metadata]
+author = Usermodel @ Rambler&Co
+author_email = um@rambler-co.ru
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Operating System :: MacOS :: MacOS X
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: Software Development :: Libraries
+description = Airflow DAGs done declaratively
+license = Apache 2.0
+long_description = file: README.rst
+maintainer = Alexander Shorin
+maintainer_email = kxepal@gmail.com
+name = airflow-declarative
+url = https://github.com/rambler-digital-solutions/airflow-declarative
+version =
+
+[mypy]
+check_untyped_defs = True
+
+[mypy-pytest.*]
+ignore_missing_imports = True
+
+[options]
+include_package_data = True
+install_requires =
+# `apache-airflow` shouldn't be here, otherwise there might be
+# a circular dependency: a patched Airflow might depend on
+# `airflow-declarative`, in which case `airflow-declarative`
+# cannot depend on Airflow.
+    croniter
+    funcsigs; python_version<"3"
+    jinja2>=2.8
+    trafaret-config==1.0.1
+    trafaret<2,>=1.0
+package_dir =
+    = src
+packages = find:
+python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
+
+[options.extras_require]
+develop =
+    apache-airflow
+    black==19.3b0; python_version>="3.6"
+    coverage==4.5.4
+    flake8==3.7.8
+    isort==4.3.21
+    mock==2.0.0
+    pylint==2.4.2; python_version>="3"
+    pytest==4.6.6
+    sphinx-rtd-theme==0.4.3
+    sphinx==2.2.0; python_version>="3"
+
+[options.packages.find]
+where = src
+
+[tool:cookiecutter_context]
+_template = new-python-project
+coverage_fail_under = 95
+metadata_author = Usermodel @ Rambler&Co
+metadata_author_email = um@rambler-co.ru
+metadata_description = Airflow DAGs done declaratively
+metadata_long_description = file: README.rst
+metadata_name = airflow-declarative
+metadata_url = https://github.com/rambler-digital-solutions/airflow-declarative
+project_dest = airflow-declarative
+project_monorepo_name =
+python_package = airflow_declarative
+
 [tool:pytest]
 addopts =
     --showlocals

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,14 @@
+from pkg_resources import get_distribution
+
+
+def test_metadata():
+    metadata_name = "airflow-declarative"
+    pkg = get_distribution(metadata_name)
+    assert pkg.version
+    assert pkg.project_name == metadata_name
+
+
+def test_package_import():
+    import airflow_declarative
+
+    assert airflow_declarative

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,10 @@ envlist=
 
 [testenv]
 deps =
+; Python 3.5 still ships an old setuptools version which doesn't support
+; declarative setup.cfg format.
+    setuptools>=41.4.0
+
     airflow1104: apache-airflow==1.10.4
     airflow1105: apache-airflow==1.10.5
     airflowdev: https://github.com/apache/airflow/archive/master.tar.gz#egg=apache-airflow


### PR DESCRIPTION
There're 2 commits here:
1. I brought some minor changes from um/new-python-project making this project closer to that template
2. I converted from setup.py to setup.cfg

The latter change would require a more recent setuptools version on the consumers side, but usually this is not a problem, unless the target platform is using ancient versions of setuptools or Python.