### PR TITLE
add support for not checking callabacks before executing

### DIFF
--- a/src/airflow_declarative/__init__.py
+++ b/src/airflow_declarative/__init__.py
@@ -23,40 +23,53 @@ from . import builder, schema, transformer
 __all__ = ("from_path", "from_dict", "render")
 
 
-def from_path(path):
+def from_path(path, check_imports=True):
     """Load DAGs from a YAML file.
 
     :param str path: A path to the declarative YAML file.
+    :param bool check_imports: Whether or not check importable objects
     :rtype: list[airflow.models.DAG]
     """
-    return from_dict(schema.from_path(path))
+    return from_dict(
+        schema.from_path(path, check_imports=check_imports), check_imports=check_imports
+    )
 
 
-def from_dict(schema):
+def from_dict(schema, check_imports=True):
     """Load DAGs from a dict (i.e. the parsed YAML file contents).
 
     :param dict schema: The declarative YAML schema.
+    :param bool check_imports: Whether or not check importable objects
     :rtype: list[airflow.models.DAG]
     """
-    return builder.build_dags(transform(schema))
+    return builder.build_dags(
+        transform(schema, check_imports=check_imports), check_imports=check_imports
+    )
 
 
-def transform(schema):
+def transform(schema, check_imports=True):
     """Preprocess the declarative YAML schema:
     - validate the schema,
     - expand the `do` block,
     - expand `defaults`.
 
     :param dict schema: The declarative YAML schema.
+    :param bool check_imports: Whether or not check importable objects
     :rtype: dict
     """
-    return transformer.transform(schema)
+    return transformer.transform(schema, check_imports=check_imports)
 
 
-def render(path):
+def render(path, check_imports=True):
     """Return the transformed schema in yaml format. Useful for debugging.
 
     :param str path: A path to the declarative YAML file.
+    :param bool check_imports: Whether or not check importable objects
     :rtype: str
     """
-    return schema.dump(transform(schema.from_path(path)))
+    return schema.dump(
+        transform(
+            schema.from_path(path, check_imports=check_imports),
+            check_imports=check_imports,
+        )
+    )

--- a/src/airflow_declarative/builder.py
+++ b/src/airflow_declarative/builder.py
@@ -20,16 +20,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from .schema import ensure_schema
 
 
-def build_dags(schema, dag_class=None, operator_class=None, sensor_class=None):
+def build_dags(
+    schema, dag_class=None, operator_class=None, sensor_class=None, check_imports=True
+):
     """
     :param dict schema: Airflow declarative DAGs schema.
     :param dag_class: DAG class. When not specified, the ``airflow.models.DAG``
                                  get used via implicit import.
     :param type operator_class: Airflow operator class.
     :param type sensor_class: Airflow sensor class.
+    :param bool check_imports: Whether or not check importable objects
     :rtype: list[airflow.models.DAG]
     """
-    schema = ensure_schema(schema)
+    schema = ensure_schema(schema, check_imports=check_imports)
 
     # We use implicit airflow imports by following reasons:
     # 1. Airflow project get renamed recently to apache-airflow, so we couldn't

--- a/src/airflow_declarative/trafaret.py
+++ b/src/airflow_declarative/trafaret.py
@@ -24,7 +24,20 @@ import re
 
 import trafaret as t
 from croniter import croniter
-from trafaret import Any, Bool, Dict, Email, Enum, Int, Key, List, Mapping, Null, String
+from trafaret import (
+    And,
+    Any,
+    Bool,
+    Dict,
+    Email,
+    Enum,
+    Int,
+    Key,
+    List,
+    Mapping,
+    Null,
+    String,
+)
 
 
 try:
@@ -34,6 +47,7 @@ except ImportError:  # pragma: no cover
 
 
 __all__ = (
+    "And",
     "Any",
     "Bool",
     "Callback",

--- a/src/airflow_declarative/transformer.py
+++ b/src/airflow_declarative/transformer.py
@@ -104,8 +104,8 @@ ENV.filters["yaml"] = yaml_filter
 ENV.add_extension(YamlExtension)
 
 
-def transform(schema):
-    schema0 = ensure_schema(schema)
+def transform(schema, check_imports=True):
+    schema0 = ensure_schema(schema, check_imports)
     schema1 = transform_templates(schema0)
     schema2 = transform_defaults(schema1)
     return schema2

--- a/tests/dags/good-without-imports/unknown-importables.yaml
+++ b/tests/dags/good-without-imports/unknown-importables.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright 2019, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+dags:
+  callbacks:
+    args:
+      start_date: 2017-07-27
+      schedule_interval: 1d
+    operators:
+      callback_task:
+        callback: 'my_module:task'
+        callback_args:
+          param: egg
+    sensors:
+      callback_sensor:
+        callback: 'my_module:Sensor'
+        callback_args:
+          param: spam

--- a/tests/test_good_without_imports.py
+++ b/tests/test_good_without_imports.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019, Rambler Digital Solutions
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import os
+
+import airflow
+import pytest
+import trafaret_config
+import yaml
+
+import airflow_declarative
+import airflow_declarative.schema
+
+from .utils import list_examples
+
+
+def param_id(param):
+    return os.path.splitext(os.path.basename(param))[0]
+
+
+def pytest_generate_tests(metafunc):
+    parameters = list_examples("good-without-imports")
+    metafunc.parametrize("path", parameters, ids=param_id)
+
+
+def test_good_dags(path):
+    dags = airflow_declarative.from_path(path, False)
+    assert isinstance(dags, list)
+    assert all(isinstance(dag, airflow.DAG) for dag in dags)
+
+
+def test_serde(path):
+    schema0 = airflow_declarative.transform(
+        airflow_declarative.schema.from_path(path, check_imports=False),
+        check_imports=False,
+    )
+    content = airflow_declarative.render(path, check_imports=False)
+    schema1 = airflow_declarative.schema.ensure_schema(
+        yaml.load(content), check_imports=False
+    )
+    assert schema0 == schema1
+
+
+def test_bad_dags(path):
+    with pytest.raises(trafaret_config.ConfigError):
+        airflow_declarative.from_path(path)


### PR DESCRIPTION
Airflow declarative supports check callback for importable. If i have different environments for airflow workers i can't build my dags.  I want the solution which can work with checking importable callbacks and not. So i add optional flag for open interface of airflow-declarative.

And i change declarative trafaret schema of constants to dynamically chema with functions for purpose of simple changing schema node with config that we can apply on schema validation.

