### PR TITLE
Add missing task and DAG args from the newer Airflow versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ python:
   - "3.8"
   - "3.9-dev"
 
-matrix:
-  allow_failures:
-    - python: "3.9-dev"
-
 install: pip install tox-travis tox tox-venv
 
 # Used by the `test` stage.
@@ -23,6 +19,9 @@ stages:
   - lint
 
 jobs:
+  allow_failures:
+    - python: "3.9-dev"
+
   include:
 
     # The `test` stage using the `python` matrix defined above

--- a/src/airflow_declarative/builder.py
+++ b/src/airflow_declarative/builder.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from .compat import test_cycle
 from .schema import ensure_schema
 
 
@@ -89,9 +90,7 @@ def build_dag(dag_id, schema, dag_class, operator_class, sensor_class):
 
     build_flow(dict(operators, **sensors), schema.get("flow", {}))
 
-    if hasattr(dag, "test_cycle"):
-        # Since Airflow 1.10
-        dag.test_cycle()
+    test_cycle(dag)
 
     return dag
 

--- a/src/airflow_declarative/compat.py
+++ b/src/airflow_declarative/compat.py
@@ -19,4 +19,20 @@ try:
 except ImportError:
     from airflow.operators import BaseOperator
 
-__all__ = ("BaseOperator", "BaseSensorOperator", "Iterable", "Mapping")
+try:
+    # Airflow master
+    from airflow.utils.dag_cycle_tester import test_cycle as _test_cycle
+except ImportError:
+    _test_cycle = None
+
+
+__all__ = ("BaseOperator", "BaseSensorOperator", "Iterable", "Mapping", "test_cycle")
+
+
+def test_cycle(dag):
+    if _test_cycle is not None:
+        # Airflow master
+        _test_cycle(dag)
+    elif hasattr(dag, "test_cycle"):
+        # Since Airflow 1.10
+        dag.test_cycle()

--- a/src/airflow_declarative/schema.py
+++ b/src/airflow_declarative/schema.py
@@ -139,6 +139,7 @@ OPERATOR_ARGS = Dict(
     {
         OptionalKey("adhoc"): BOOLEAN,
         OptionalKey("depends_on_past"): BOOLEAN,
+        OptionalKey("do_xcom_push"): BOOLEAN,
         OptionalKey("email"): EMAIL,
         OptionalKey("email_on_failure"): BOOLEAN,
         OptionalKey("email_on_retry"): BOOLEAN,
@@ -217,18 +218,25 @@ FLOW = Mapping(key=STRING, value=List(STRING, min_length=1))
 
 DAG_ARGS = Dict(
     {
+        OptionalKey("access_control"): Dict(allow_extra="*"),
         OptionalKey("catchup"): BOOLEAN,
         OptionalKey("concurrency"): POSITIVE_INT,
         OptionalKey("dagrun_timeout"): INTERVAL,
         # Sensor args is a superset of all the args.
         OptionalKey("default_args"): SENSOR_ARGS,
+        OptionalKey("default_view"): STRING,
         OptionalKey("description"): STRING,
+        OptionalKey("doc_md"): STRING,
         OptionalKey("end_date"): DATE,
+        OptionalKey("is_paused_upon_creation"): BOOLEAN,
+        OptionalKey("jinja_environment_kwargs"): Dict(allow_extra="*"),
         OptionalKey("max_active_runs"): POSITIVE_INT,
         OptionalKey("orientation"): STRING,
+        OptionalKey("params"): PARAMS,
         OptionalKey("schedule_interval"): NULL | CRON_PRESETS | CRONTAB_OR_INTERVAL,
         OptionalKey("sla_miss_callback"): CALLBACK,
         OptionalKey("start_date"): DATE,
+        OptionalKey("tags"): List(STRING),
     }
 )
 

--- a/tests/test_bad_dags.py
+++ b/tests/test_bad_dags.py
@@ -64,7 +64,9 @@ def pytest_generate_tests(metafunc):
             ),
             zip(
                 list_examples("logic-errors"),
-                itertools.repeat((RuntimeError, TypeError)),
+                itertools.repeat(
+                    (RuntimeError, TypeError, airflow.exceptions.AirflowException)
+                ),
             ),
             zip(
                 list_examples("airflow-errors"),

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist=
     py{27,35,36,37,38,39}-airflow1104,
     py{27,35,36,37,38,39}-airflow1105,
+    py{27,35,36,37,38,39}-airflow1109,
     py{35,36,37,38,39}-airflowdev,
     lint,
     check-docs,
@@ -14,6 +15,7 @@ deps =
 
     airflow1104: apache-airflow==1.10.4
     airflow1105: apache-airflow==1.10.5
+    airflow1109: apache-airflow==1.10.9
     airflowdev: https://github.com/apache/airflow/archive/master.tar.gz#egg=apache-airflow
 extras =
     develop

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist=
     py{27,35,36,37,38,39}-airflow1104,
     py{27,35,36,37,38,39}-airflow1105,
     py{27,35,36,37,38,39}-airflow1109,
-    py{35,36,37,38,39}-airflowdev,
+    py{36,37,38,39}-airflowdev,
     lint,
     check-docs,
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist=
     py{27,35,36,37,38,39}-airflow1104,
     py{27,35,36,37,38,39}-airflow1105,
     py{27,35,36,37,38,39}-airflow1109,
+    py{27,35,36,37,38,39}-airflow11010,
     py{36,37,38,39}-airflowdev,
     lint,
     check-docs,
@@ -16,6 +17,7 @@ deps =
     airflow1104: apache-airflow==1.10.4
     airflow1105: apache-airflow==1.10.5
     airflow1109: apache-airflow==1.10.9
+    airflow11010: apache-airflow==1.10.10
     airflowdev: https://github.com/apache/airflow/archive/master.tar.gz#egg=apache-airflow
 extras =
     develop


### PR DESCRIPTION
Airflow has added new DAG and task args which are currently not supported by airflow-declarative.

Relevant Airflow docs:
- https://airflow.apache.org/docs/stable/_api/airflow/models/index.html#airflow.models.DAG
- https://airflow.apache.org/docs/stable/_api/airflow/models/index.html#airflow.models.BaseOperator

I checked only the `tags` field (I don't need the other ones) -- it works fine.